### PR TITLE
Report period, validity and updated comments

### DIFF
--- a/contracts/MarketSource.sol
+++ b/contracts/MarketSource.sol
@@ -8,68 +8,75 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
  * @title Market Source
  * @notice https://www.fragments.org/protocol/
  *
- * @dev This contract provides the USD-UFragments exchange rate and volume from a single offchain
- *      market source.
+ * @dev This contract provides the UFragments-USD exchange rate and total volume of
+ *      UFragments traded over the past 24-hours, as reported by a single offchain market source.
  */
 contract MarketSource is Destructible {
     using SafeMath for uint256;
 
-    // It signifies the number of decimal places in the reported exchange rate
-    uint8 public constant DECIMALS = 18;
-
     // Name of the source reporting exchange rates
     string public name;
 
+    // The amount of time after which the report must be deemed expired
     uint256 public constant REPORT_EXPIRATION_TIME = 1 hours;
 
     struct Report {
         uint256 exchangeRate;
-        uint256 volume;
+        uint256 volume24hrs;
         uint256 timestamp;
     }
 
     // Most recent report from the source
     Report public report;
 
-    event ExchangeRateReported(uint256 exchangeRate, uint256 volume, uint256 indexed timestamp);
+    event ExchangeRateReported(uint256 exchangeRate, uint256 volume24hrs, uint256 indexed timestamp);
 
     constructor(string _name) public {
         name = _name;
     }
 
     /**
-     * @dev Source reports the most recent exchange rate to the blockchain.
-     * @param exchangeRate the fragments to USD exchange rate (eg) 105
-     * @param volume the total trade volume traded at the given rate
+     * @dev The MarketSource commits to the blockchain, the most recent
+     *      exchangeRate and 24-hour trade volume as observed.
+     * @param exchangeRate The average UFragments-USD exchange rate over the previous 24-hours
+     *         as observed by the MarketSource. The submitted exchange rate is an
+     *         18 point fixed float.
+     *        (eg) 1500000000000000000 (1.5e18) means the rate is  [1.5 USD = 1 UFragments]
+     * @param volume24hrs The total trade volume of UFragments traded over the previous 24-hours.
+     *        The submitted volume is a 2 point fixed float.
+     *        (eg) 12350032 means 123500.32 UFragments were being traded.
      */
-    function reportRate(uint256 exchangeRate, uint256 volume) public onlyOwner {
+    function reportRate(uint256 exchangeRate, uint256 volume24hrs) public onlyOwner {
+        require(exchangeRate > 0);
+        require(volume24hrs > 0);
+
         report = Report({
             exchangeRate: exchangeRate,
-            volume: volume,
+            volume24hrs: volume24hrs,
             timestamp: now
         });
-        emit ExchangeRateReported(exchangeRate, volume, now);
+
+        emit ExchangeRateReported(exchangeRate, volume24hrs, now);
     }
 
     /**
-     * @return The most recently reported exchange rate.
+     * @return Most recently reported exchange rate.
      */
     function exchangeRate() public view returns (uint256) {
         return report.exchangeRate;
     }
 
     /**
-     * @return The most recently reported trade volume.
+     * @return Most recently reported trade volume.
      */
     function volume() public view returns (uint256) {
-        return report.volume;
+        return report.volume24hrs;
     }
 
     /**
-     * @return If the most recent report was made atmost {REPORT_EXPIRATION_TIME}
-     * from the current block.
+     * @return If less than {REPORT_EXPIRATION_TIME} has passed since the most recent report.
      */
-    function isValid() public view returns (bool) {
+    function isActive() public view returns (bool) {
         return (report.timestamp + REPORT_EXPIRATION_TIME > now);
     }
 }

--- a/test/logs/gas-utilization.yaml
+++ b/test/logs/gas-utilization.yaml
@@ -1,5 +1,5 @@
 # Code generated - DO NOT EDIT.
 # Any manual changes may be lost.
-'MarketSourceFactory:DEPLOYMENT': 924365
-'MarketOracle:DEPLOYMENT': 1115651
-'MarketOracle:getPriceAndVolume(10 sources)': 137349
+'MarketSourceFactory:DEPLOYMENT': 1013116
+'MarketOracle:DEPLOYMENT': 1133401
+'MarketOracle:getPriceAndVolume(10 sources)': 136469


### PR DESCRIPTION
Addressing [#2160421](https://www.pivotaltracker.com/n/projects/2160421)

* Using the term `active` instead of `valid` to indicate if a report has not expired.
* More descriptive comments.
* Additional validation in the reportRate function.

----------------------
W.R.T Item(4) on pivotal:  #RFC

Currently `getPriceAndVolume` does not fail gracefully when none of the whitelisted sources have an `active` report. This causes the subsequent `Rebase` call to fail. 
When no source has reported any rate the expected behavior is for the uFragments supply to not change.  Which will happen in this case.

If we want to handle this in the `MarketOrace` we would need to keep track of the last valid exchangeRate and volume reported out, on the MarketOracle contract and return the previous value in case of failure. (Costs additional storage)

I'm okay with the rebase failing and causing a revert, even though it's not clean. 
What do you guys think? 


