### PR TITLE
Fixed bug when deleting multiple sources

### DIFF
--- a/contracts/MarketOracle.sol
+++ b/contracts/MarketOracle.sol
@@ -32,7 +32,7 @@ contract MarketOracle is Ownable {
         uint256 volumeWeightedSum = 0;
         uint256 volume = 0;
 
-        for (uint256 i = 0; i < whitelist.length; i++) {
+        for (uint8 i = 0; i < whitelist.length; i++) {
             if (!whitelist[i].isActive()) {
                 emit LogSourceExpired(whitelist[i]);
                 continue;
@@ -74,9 +74,12 @@ contract MarketOracle is Ownable {
      * @dev Performs a linear scan on the whitelisted sources and removes any dead market sources
      */
     function removeDeadSources() external {
-        for (uint8 i = 0; i < whitelist.length; i++) {
+        uint8 i = 0;
+        while (i < whitelist.length) {
             if (isContractDead(whitelist[i])) {
                 removeSource(i);
+            } else {
+                i++;
             }
         }
     }


### PR DESCRIPTION
Consider a the whitelist `[s1, s2, s3]`.  (Say, s1 and s3 are dead)

Deletion from an array works by moving the last element in the array to the element to be deleted and then reducing the size of the array.
(eg) If s1 needs to be deleted from [s1, s2, s3] => The result is [s3, s2]

There's a bug in the `removeDeadSources` function which will fail to delete all dead sources if the source at the end of the list is dead.
Iteration 1: [[s1], s2, s3] => [s3, s2]
Iteration 2: [s3, [s2]] => [s3, s2]

We weren't testing this condition earlier. Wrote a failing test for this. https://github.com/frgprotocol/market-oracle/pull/13


---

Modified iterator in`getPriceAndVolume` to `uint8` to keep it consistent with `removeSource`
