### PR TITLE
breaking after removing matched source

### DIFF
--- a/contracts/MarketOracle.sol
+++ b/contracts/MarketOracle.sol
@@ -68,6 +68,7 @@ contract MarketOracle is Ownable {
         for (uint8 i = 0; i < whitelist.length; i++) {
             if (whitelist[i] == source) {
                 removeSource(i);
+                break;
             }
         }
     }


### PR DESCRIPTION
Exiting the linear scan when the source address is matched and removed.

```
       for (uint8 i = 0; i < whitelist.length; i++) {
            if (whitelist[i] == source) {
                removeSource(i);
                break;
            }
        }
```

In the edge case when the whitelist is polluted with duplicate source addresses, we could just call removeSource multiple times to remove all instances of the source address from the whitelist. 