### PR TITLE
Add comment to never whitelist mutable/upgradeable market sources

### DIFF
--- a/contracts/MarketOracle.sol
+++ b/contracts/MarketOracle.sol
@@ -64,7 +64,8 @@ contract MarketOracle is Ownable {
 
     /**
      * @dev Adds a market source to the whitelist.
-     * To avoid changes in the market source, never whitelist mutable/upgradeable market sources
+     * Upgradeable contracts should never be added,
+     * because the logic could be changed after the whitelisting process.
      * @param source Address of the MarketSource.
      */
     function addSource(MarketSource source)


### PR DESCRIPTION
Add comment     * To avoid changes in the market source, never whitelist mutable/upgradeable market sources