### PR TITLE
Fix for failing nightly build

### DIFF
--- a/test/unit/market_source.js
+++ b/test/unit/market_source.js
@@ -119,6 +119,6 @@ contract('MarketSource:destroy', function (accounts) {
 
   it('should terminate the contract on the  blockchain', async function () {
     await source.destroy({ from: A });
-    expect(await web3.eth.getCode(source.address)).to.eq('0x0');
+    expect(await chain.isContract(source.address)).not.to.be.true;
   });
 });

--- a/util/blockchain_caller.js
+++ b/util/blockchain_caller.js
@@ -53,7 +53,7 @@ BlockchainCaller.prototype.getBlockGasLimit = async function () {
 BlockchainCaller.prototype.isContract = async function (address) {
   // getCode returns '0x0' if address points to a wallet else it returns the contract bytecode
   const code = await this.web3.eth.getCode(address);
-  return (code !== '0x0');
+  return (code !== '0x0' && code !== '0x');
 };
 
 module.exports = BlockchainCaller;


### PR DESCRIPTION
`web3.eth.getCode()` retruns `0x` when interacting with ganache and `0x0` in the case of geth.

https://travis-ci.com/frgprotocol/market-oracle/builds/94303066